### PR TITLE
initialize calendar to valid date, ensure picker within valid days only

### DIFF
--- a/src/css/angular-datepicker.css
+++ b/src/css/angular-datepicker.css
@@ -159,3 +159,6 @@ datepicker,
   background: rgba(25,2,0,0.02);
   cursor: default;
 }
+.datepicker-calendar .hidden {
+  visibility: hidden;
+}


### PR DESCRIPTION
We frequently have requirements to pick days that are long before or after the current date making it difficult for uses to find a valid date.  This PR ensures the picker defaults to a valid date and removes navigation to dates/years that are invalid.
