### PR TITLE
Add min and max date to isolate scope

### DIFF
--- a/src/js/angular-datepicker.js
+++ b/src/js/angular-datepicker.js
@@ -11,7 +11,8 @@
     return {
       'restrict': 'E',
       'scope': {
-        'dateSet': '@'
+        'dateSet': '@',
+        'dateMinLimit': '@',
       },
       'link': function linkingFunction($scope, element, attr) {
         //get child input
@@ -23,8 +24,8 @@
           , prevButton = attr.buttonPrev || defaultPrevButton
           , nextButton = attr.buttonNext || defaultNextButton
           , dateFormat = attr.dateFormat
-          , dateMinLimit = attr.dateMinLimit || undefined
           , dateMaxLimit = attr.dateMaxLimit || undefined
+          , dateMinLimit 
           , date = new Date()
           , isMouseOn = false
           , isMouseOnInput = false
@@ -88,6 +89,12 @@
             $scope.monthNumber = Number($filter('date')(date, 'MM')); // 01-12 like
             $scope.day = Number($filter('date')(date, 'dd')); //01-31 like
             $scope.year = Number($filter('date')(date, 'yyyy'));//2014 like
+          }
+        });
+
+        $scope.$watch('dateMinLimit', function (value) {
+          if (value) {
+            dateMinLimit = value;
           }
         });
 

--- a/src/js/angular-datepicker.js
+++ b/src/js/angular-datepicker.js
@@ -25,8 +25,8 @@
           , prevButton = attr.buttonPrev || defaultPrevButton
           , nextButton = attr.buttonNext || defaultNextButton
           , dateFormat = attr.dateFormat
-          , dateMinLimit 
-          , dateMaxLimit 
+          , dateMinLimit
+          , dateMaxLimit
           , date = new Date()
           , isMouseOn = false
           , isMouseOnInput = false

--- a/src/js/angular-datepicker.js
+++ b/src/js/angular-datepicker.js
@@ -13,6 +13,7 @@
       'scope': {
         'dateSet': '@',
         'dateMinLimit': '@',
+        'dateMaxLimit': '@'
       },
       'link': function linkingFunction($scope, element, attr) {
         //get child input
@@ -24,8 +25,8 @@
           , prevButton = attr.buttonPrev || defaultPrevButton
           , nextButton = attr.buttonNext || defaultNextButton
           , dateFormat = attr.dateFormat
-          , dateMaxLimit = attr.dateMaxLimit || undefined
           , dateMinLimit 
+          , dateMaxLimit 
           , date = new Date()
           , isMouseOn = false
           , isMouseOnInput = false
@@ -95,6 +96,12 @@
         $scope.$watch('dateMinLimit', function (value) {
           if (value) {
             dateMinLimit = value;
+          }
+        });
+
+        $scope.$watch('dateMaxLimit', function (value) {
+          if (value) {
+            dateMaxLimit = value;
           }
         });
 


### PR DESCRIPTION
I added dateMinLimit & dateMaxLimit to the directive isolate scope and then set up $watch on them. If they're present, I set the var dateMinLimit/dateMaxLimit to the value of date-min-limit/date-max-limit.

This was useful when I was using two date pickers to make a date range. I thought it would be nice if the user could not select a fromDate that is further in the future than their chosen toDate. 

This allows for a more flexible min and max date limits. Also, you can still hard-code a date.

```html
<datepicker date-max-limit="{{toDate}}">
  <input ng-model="fromDate" type="text"/>
</datepicker>

<datepicker>
  <input ng-model="toDate" type="text"/>
</datepicker>
```

![screen shot 2015-01-06 at 21 29 02](https://cloud.githubusercontent.com/assets/5764316/5635725/1e3cddc8-95ec-11e4-9eab-4e319d338838.png)