### PR TITLE
* Updated datepicker to respect previously set interpolation begin / end.

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -3,8 +3,14 @@
 (function (angular) {
   'use strict';
 
-  angular.module('720kb', [
+  var app = angular.module('720kb', [
     'ngRoute',
     '720kb.datepicker'
   ]);
+  
+  // Setup interpolation to use [[ / ]]
+  app.config(function($interpolateProvider) {
+        // Setup angular to use [[ expression ]] instead of {{ expression }}
+        $interpolateProvider.startSymbol('[[').endSymbol(']]');
+  });
 }(angular));

--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
       <div datepicker>
         <input ng-model="date1" type="text" class="angular-datepicker-input"/>
       </div>
-      Date 1 is: {{date1}}
+      Date 1 is: [[date1]]
     </div>
     <div class="col3">
       <div class="datepicker"
@@ -33,13 +33,13 @@
       button-next='<i class="fa fa-arrow-circle-right"></i>'>
       <input ng-model="date2" type="text" class="angular-datepicker-input"/>
     </div>
-    Date 2 is: {{date2}}
+    Date 2 is: [[date2]]
   </div>
   <div class="col3">
     <datepicker>
       <input ng-model="date3" type="text" class="angular-datepicker-input"/>
     </datepicker>
-    Date 3 is: {{date3}}
+    Date 3 is: [[date3]]
   </div>
 </div>
 <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.4/angular.min.js"></script>

--- a/src/js/angular-datepicker.js
+++ b/src/js/angular-datepicker.js
@@ -5,7 +5,7 @@
   'use strict';
 
   angular.module('720kb.datepicker', [])
-  .directive('datepicker', ['$window', '$compile', '$locale', '$filter', function manageDirective($window, $compile, $locale, $filter) {
+		.directive('datepicker', ['$window', '$compile', '$locale', '$filter', '$interpolate', function manageDirective($window, $compile, $locale, $filter, $interpolate) {
 
     var A_DAY_IN_MILLISECONDS = 86400000;
     return {
@@ -81,8 +81,11 @@
           '<a href="javascript:void(0)" ng-repeat="nx in nextMonthDays" class="_720kb-datepicker-calendar-day _720kb-datepicker-disabled">{{nx}}</a>' +
           '</div>' +
           '</div>' +
-          '</div>';
+			'</div>';
 
+        // Respect previously configured interpolation symbols.
+        htmlTemplate = htmlTemplate.replace(/{{/g, $interpolate.startSymbol())
+            .replace(/}}/g, $interpolate.endSymbol());
         $scope.$watch('dateSet', function dateSetWatcher(value) {
           if (value) {
             date = new Date(value);


### PR DESCRIPTION
Currently angular-datepicker does not respect the interpolation markers set by the interpolation provider.  This means if the markers are set to something else like - [[ / ]], then the calendar does not render correctly.  Instead we receive the raw template with uninterpolated {{ / }}.

My changes fix this and demonstrate the fix.  You may not want to merge in the html / index.js changes.  I just provided them to demonstrate the fix.