### PR TITLE
stopped dates outside of min and max limits from being selected

### DIFF
--- a/src/js/angular-datepicker.js
+++ b/src/js/angular-datepicker.js
@@ -454,11 +454,11 @@
 
         $scope.setDatepickerDay = function setDatepickeDay(day) {
 
-          if ($scope.isSelectableDate($scope.monthNumber, $scope.year, day)) {
-
-            $scope.day = Number(day);
-            $scope.setInputValue();
-            $scope.hideCalendar();
+          if ($scope.isSelectableMaxDate($scope.year + '/' + $scope.monthNumber + '/' + day)
+              && $scope.isSelectableMinDate($scope.year + '/' + $scope.monthNumber + '/' + day)) {
+              $scope.day = Number(day);
+              $scope.setInputValue();
+              $scope.hideCalendar();
           }
         };
 

--- a/src/js/angular-datepicker.js
+++ b/src/js/angular-datepicker.js
@@ -454,7 +454,8 @@
 
         $scope.setDatepickerDay = function setDatepickeDay(day) {
 
-          if ($scope.isSelectableMaxDate($scope.year + '/' + $scope.monthNumber + '/' + day)
+          if ($scope.isSelectableDate($scope.monthNumber, $scope.year, day)
+              && $scope.isSelectableMaxDate($scope.year + '/' + $scope.monthNumber + '/' + day)
               && $scope.isSelectableMinDate($scope.year + '/' + $scope.monthNumber + '/' + day)) {
               $scope.day = Number(day);
               $scope.setInputValue();


### PR DESCRIPTION
days outside of the min/max limits could be selected. although the date wouldn't change in the textbox, the day in the calendar would be set to 'active' and the calendar would close.