### PR TITLE
Added attribute to make datepicker visible on page load

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,15 @@ Sometimes you cannot put date input as a first child of datepicker. In this case
 </datepicker>
 ```
 
+####Datepicker visible on load
+You have an option to make the datepicker visible when it loads with `visible-on-load` attribute.
+
+```html
+<datepicker visible-on-load>
+    <input placeholder="Choose a date"/>
+</datepicker>
+```
+
 ### Example
 
 [Live demo](https://720kb.github.io/angular-datepicker)

--- a/src/js/angular-datepicker.js
+++ b/src/js/angular-datepicker.js
@@ -651,6 +651,10 @@
           angular.element(theCalendar).off('mouseenter mouseleave focusin');
           angular.element($window).off('click focus');
         });
+        
+        if (attr.hasOwnProperty('visibleOnLoad')) {
+          showCalendar();
+        }
       };
 
       return {


### PR DESCRIPTION
Issue  #88 

When you use <datepicker visible-on-load> the calender is shown when the page has loaded