### PR TITLE
added asCalendar attr

### DIFF
--- a/src/js/angular-datepicker.js
+++ b/src/js/angular-datepicker.js
@@ -430,11 +430,12 @@
         };
 
         $scope.hideCalendar = function hideCalendar() {
-          if (theCalendar.classList){
-            theCalendar.classList.remove('_720kb-datepicker-open');
-          } else {
-
-            classHelper.remove(theCalendar, '_720kb-datepicker-open');
+          if (!attr.hasOwnProperty('asCalendar')) {
+            if (theCalendar.classList){
+              theCalendar.classList.remove('_720kb-datepicker-open');
+            } else {
+              classHelper.remove(theCalendar, '_720kb-datepicker-open');
+            }
           }
         };
 
@@ -651,14 +652,13 @@
         setDaysInMonth($scope.monthNumber, $scope.year);
 
         $scope.$on('$destroy', function unregisterListener() {
-
           unregisterDataSetWatcher();
           thisInput.off('focus click focusout blur');
           angular.element(theCalendar).off('mouseenter mouseleave focusin');
           angular.element($window).off('click focus');
         });
 
-        if (attr.hasOwnProperty('visibleOnLoad')) {
+        if (attr.hasOwnProperty('visibleOnLoad') || attr.hasOwnProperty('asCalendar')) {
           showCalendar();
         }
       };


### PR DESCRIPTION
The datepicker can be used as an actual calendar. The code is checking for the attr asCalendar and if that exists then it don't hide the datepicker when clicking anything, but keeps it open for use as an calandar, im using this in my code tweeking the look of the datepicker with css. then it is up to the user if they wan't to hide the input element or not!