### PR TITLE
Change month when dateMinLimit is set

### DIFF
--- a/src/js/angular-datepicker.js
+++ b/src/js/angular-datepicker.js
@@ -387,12 +387,14 @@
             }
           })
           , unregisterDateMaxLimitWatcher = $scope.$watch('dateMaxLimit', function dateMaxLimitWatcher(newValue){
-            if(newValue)
+            if(newValue){
               resetToMaxDate();
+            }
           })
           , unregisterDateFormatWatcher = $scope.$watch('dateFormat', function dateFormatWatcher(newValue){
-            if(newValue)
+            if(newValue){
               setInputValue();
+            }
           });
 
         $scope.nextMonth = function nextMonth() {

--- a/src/js/angular-datepicker.js
+++ b/src/js/angular-datepicker.js
@@ -183,6 +183,8 @@
             $scope.monthNumber = Number($filter('date')(new Date($scope.dateMaxLimit), 'MM'));
             $scope.day = Number($filter('date')(new Date($scope.dateMaxLimit), 'dd'));
             $scope.year = Number($filter('date')(new Date($scope.dateMaxLimit), 'yyyy'));
+
+            setDaysInMonth($scope.monthNumber, $scope.year);
           }
           , prevYear = function prevYear() {
 
@@ -383,6 +385,14 @@
             if(newValue){
               resetToMinDate();
             }
+          })
+          , unregisterDateMaxLimitWatcher = $scope.$watch('dateMaxLimit', function dateMaxLimitWatcher(newValue){
+            if(newValue)
+              resetToMaxDate();
+          })
+          , unregisterDateFormatWatcher = $scope.$watch('dateFormat', function dateFormatWatcher(newValue){
+            if(newValue)
+              setInputValue();
           });
 
         $scope.nextMonth = function nextMonth() {
@@ -839,6 +849,8 @@
 
           unregisterDataSetWatcher();
           unregisterDateMinLimitWatcher();
+          unregisterDateMaxLimitWatcher();
+          unregisterDateFormatWatcher();
           thisInput.off('focus click focusout blur');
           angular.element(theCalendar).off('mouseenter mouseleave focusin');
           angular.element($window).off('click focus focusin', onClickOnWindow);

--- a/src/js/angular-datepicker.js
+++ b/src/js/angular-datepicker.js
@@ -838,7 +838,7 @@
         $scope.$on('$destroy', function unregisterListener() {
 
           unregisterDataSetWatcher();
-          unRegisterDateMinLimitWatcher();
+          unregisterDateMinLimitWatcher();
           thisInput.off('focus click focusout blur');
           angular.element(theCalendar).off('mouseenter mouseleave focusin');
           angular.element($window).off('click focus focusin', onClickOnWindow);

--- a/src/js/angular-datepicker.js
+++ b/src/js/angular-datepicker.js
@@ -175,7 +175,7 @@
             $scope.day = Number($filter('date')(new Date($scope.dateMinLimit), 'dd'));
             $scope.year = Number($filter('date')(new Date($scope.dateMinLimit), 'yyyy'));
 			
-			setDaysInMonth($scope.monthNumber, $scope.year);
+            setDaysInMonth($scope.monthNumber, $scope.year);
           }
           , resetToMaxDate = function resetToMaxDate() {
 
@@ -378,6 +378,11 @@
                 setInputValue();
               }
             }
+          })
+          , unregisterDateMinLimitWatcher = $scope.$watch('dateMinLimit', function dateMinLimitWatcher(newValue){
+            if(newValue){
+              resetToMinDate();
+            }
           });
 
         $scope.nextMonth = function nextMonth() {
@@ -488,13 +493,7 @@
           $scope.monthNumber = Number($filter('date')(new Date(selectedMonthNumber + '/01/2000'), 'MM'));
           setDaysInMonth($scope.monthNumber, $scope.year);
           setInputValue();
-        };
-		
-		$scope.$watch('dateMinLimit', function(){
-			if($scope.dateMinLimit)
-				resetToMinDate();
-		})
-
+        };	
 
         $scope.setNewYear = function setNewYear(year) {
 
@@ -839,6 +838,7 @@
         $scope.$on('$destroy', function unregisterListener() {
 
           unregisterDataSetWatcher();
+          unRegisterDateMinLimitWatcher();
           thisInput.off('focus click focusout blur');
           angular.element(theCalendar).off('mouseenter mouseleave focusin');
           angular.element($window).off('click focus focusin', onClickOnWindow);

--- a/src/js/angular-datepicker.js
+++ b/src/js/angular-datepicker.js
@@ -174,6 +174,8 @@
             $scope.monthNumber = Number($filter('date')(new Date($scope.dateMinLimit), 'MM'));
             $scope.day = Number($filter('date')(new Date($scope.dateMinLimit), 'dd'));
             $scope.year = Number($filter('date')(new Date($scope.dateMinLimit), 'yyyy'));
+			
+			setDaysInMonth($scope.monthNumber, $scope.year);
           }
           , resetToMaxDate = function resetToMaxDate() {
 
@@ -487,6 +489,12 @@
           setDaysInMonth($scope.monthNumber, $scope.year);
           setInputValue();
         };
+		
+		$scope.$watch('dateMinLimit', function(){
+			if($scope.dateMinLimit)
+				resetToMinDate();
+		})
+
 
         $scope.setNewYear = function setNewYear(year) {
 


### PR DESCRIPTION
In one of my applications, I have two linked datepickers, one called "start" and other called "finish." When I choose the start date, I want the "finish" datepicker to move to the month I chose on "start" datepicker. I am now able to do that with this little change and setting date-min-limit. 

I do not know if this is the best way to solve this problem; however, it worked for me so I wanted to contribute.

Please let me know if I was not clear enough or you need more details.