### PR TITLE
Setting selected date on first time showCalendar() call

### DIFF
--- a/src/js/angular-datepicker.js
+++ b/src/js/angular-datepicker.js
@@ -158,6 +158,7 @@
           //, dateMaxLimit
           , dateDisabledDates = $scope.$eval($scope.dateDisabledDates)
           , date = new Date()
+          , dateString
           , isMouseOn = false
           , isMouseOnInput = false
           , preventMobile = typeof attr.datepickerMobile !== 'undefined' && attr.datepickerMobile !== 'false'
@@ -348,6 +349,11 @@
             if (theCalendar.classList) {
 
               theCalendar.classList.add('_720kb-datepicker-open');
+              dateString = angular.element((angular.element(theCalendar).parent()[0]).querySelector('input')).val().replace(/\//g, '-');
+              date = new Date(dateString);
+              $scope.selectedMonth = Number($filter('date')(date, 'MM'));
+              $scope.selectedDay = Number($filter('date')(date, 'dd'));
+              $scope.selectedYear = Number($filter('date')(date, 'yyyy'));
             } else {
 
               classHelper.add(theCalendar, '_720kb-datepicker-open');

--- a/src/js/angular-datepicker.js
+++ b/src/js/angular-datepicker.js
@@ -349,7 +349,7 @@
             if (theCalendar.classList) {
 
               theCalendar.classList.add('_720kb-datepicker-open');
-              dateString = angular.element((angular.element(theCalendar).parent()[0]).querySelector('input')).val().replace(/\//g, '-');
+              dateString = angular.element(angular.element(theCalendar).parent()[0].querySelector('input')).val().replace(/\//g, '-');
               date = new Date(dateString);
               $scope.selectedMonth = Number($filter('date')(date, 'MM'));
               $scope.selectedDay = Number($filter('date')(date, 'dd'));


### PR DESCRIPTION
When datepicker opens first time, the `selectedDay`, `selectedMonth` and `selectedYear` are not initialised, which prevent the active class from being applied. This works on subsequent opens though, once `setDatepickerDay` has been called.

Tested this PR on Chrome, Safari, Firefox and IE