### PR TITLE
Extending logic to set month and year

### DIFF
--- a/src/js/angular-datepicker.js
+++ b/src/js/angular-datepicker.js
@@ -349,11 +349,13 @@
             if (theCalendar.classList) {
 
               theCalendar.classList.add('_720kb-datepicker-open');
+              // set selected date components (from datepicker input field) on show
               dateString = angular.element(angular.element(theCalendar).parent()[0].querySelector('input')).val().replace(/\//g, '-');
               date = new Date(dateString);
-              $scope.selectedMonth = Number($filter('date')(date, 'MM'));
-              $scope.selectedDay = Number($filter('date')(date, 'dd'));
-              $scope.selectedYear = Number($filter('date')(date, 'yyyy'));
+              $scope.selectedMonth = $scope.monthNumber = Number($filter('date')(date, 'MM'));
+              $scope.selectedDay = $scope.day = Number($filter('date')(date, 'dd'));
+              $scope.selectedYear = $scope.year = Number($filter('date')(date, 'yyyy'));
+              $scope.month = $filter('date')(new Date($scope.year, $scope.monthNumber - 1), 'MMMM');
             } else {
 
               classHelper.add(theCalendar, '_720kb-datepicker-open');


### PR DESCRIPTION
If initial date has month and year different from current date, then this patch will show day/month/year selection. Ran `npm run lint` too.