### PR TITLE
Invalid date pickup for locale date format

### DIFF
--- a/src/js/angular-datepicker.js
+++ b/src/js/angular-datepicker.js
@@ -278,45 +278,55 @@
           }
           , localDateTimestamp = function localDateTimestamp(rawDate, dateFormatDefinition) {
             
-            var formattingTokens = /(\[[^\[]*\])|(\\)?([Hh]mm(ss)?|MM?M?M?|dd?d?|yy?yy?y?|gg(ggg?)?|GG(GGG?)?|e|E|a|A|hh?|HH?|kk?|mm?|ss?|S{1,9}|x|X|zz?|ZZ?|.)/g
-            ,formatDate = dateFormatDefinition.match(formattingTokens)
-            ,dateSplit, m, d, y, index, el;
+            var formattingTokens = /(\[[^\[]*\])|(\\)?([Hh]mm(ss)?|MMMM|MMM|MM|M|dd?d?|yy?yy?y?|gg(ggg?)?|GG(GGG?)?|e|E|a|A|hh?|HH?|kk?|mm?|ss?|S{1,9}|x|X|zz?|ZZ?|.)/g
+            ,formatDate,dateSplit, m, d, y, index, el, longName, shortName;
 
             for (index = 0; index < datetime.MONTH.length; index += 1) {
-              el = datetime.MONTH[index];
-              if (rawDate.indexOf(el) > -1) {
-                rawDate = rawDate.replace(el, index + 1);
+              longName = datetime.MONTH[index];
+              shortName = datetime.SHORTMONTH[index];
+
+              if (rawDate.indexOf(longName) !== -1) {
+                rawDate = rawDate.replace(longName, index + 1);
                 break;
               }
+
+              if (rawDate.indexOf(shortName) !== -1) {
+                rawDate = rawDate.replace(shortName, index + 1);
+                break;
+              }              
             }
 
-            dateSplit = rawDate.split(/\D/);
+            dateSplit = rawDate
+              .split(/\D/)
+              .filter(function dateSplitFilter(item) {
+                return item.length > 0;
+              });
 
-            dateSplit = dateSplit.filter(function dateSplitFilter(item) {
-              if (item.length > 0) {
-                return item;
-              }
-            });
-
-            formatDate = formatDate.filter(function fromatDateFilter(item) {
-              if (item.match(/^[a-zA-Z]+$/i) !== null) {
-                return item;
-              }
-            });
+            formatDate = dateFormatDefinition
+              .match(formattingTokens)
+              .filter(function fromatDateFilter(item) {
+                return item.match(/^[a-zA-Z]+$/i) !== null;
+              });
 
             for (index = 0; index < formatDate.length; index += 1) {
               el = formatDate[index];
 
-              if (el.indexOf('d') > -1) {
-                d = dateSplit[index];
-              }
-
-              if (el.indexOf('M') > -1) {
-                m = dateSplit[index];
-              }
-
-              if (el.indexOf('y') > -1) {
-                y = dateSplit[index];
+              switch (true) {
+                case el.indexOf('d') !== -1: {
+                  d = dateSplit[index];
+                  break;
+                }
+                case el.indexOf('M') !== -1: {
+                  m = dateSplit[index];
+                  break;
+                }
+                case el.indexOf('y') !== -1: {
+                  y = dateSplit[index];
+                  break; 
+                }
+                default: {
+                  break;  
+                }                                 
               }
             }
 

--- a/src/js/angular-datepicker.js
+++ b/src/js/angular-datepicker.js
@@ -276,35 +276,46 @@
 
             $scope.year = Number($scope.year) + 1;
           }
-          , localDateTimestamp = function localDateTimestamp(rawDate, dateFormat) {
+          , localDateTimestamp = function localDateTimestamp(rawDate, dateFormatDefinition) {
             
-            var formattingTokens = /(\[[^\[]*\])|(\\)?([Hh]mm(ss)?|MM?M?M?|dd?d?|yy?yy?y?|gg(ggg?)?|GG(GGG?)?|e|E|a|A|hh?|HH?|kk?|mm?|ss?|S{1,9}|x|X|zz?|ZZ?|.)/g;
-            var formatDate = dateFormat.match(formattingTokens);
-            var dateSplit = rawDate.split(/\D/);
-            var m;
-            var d;
-            var y;
+            var formattingTokens = /(\[[^\[]*\])|(\\)?([Hh]mm(ss)?|MM?M?M?|dd?d?|yy?yy?y?|gg(ggg?)?|GG(GGG?)?|e|E|a|A|hh?|HH?|kk?|mm?|ss?|S{1,9}|x|X|zz?|ZZ?|.)/g
+            ,formatDate = dateFormatDefinition.match(formattingTokens)
+            ,dateSplit, m, d, y, index, el;
 
-            console.log('tutu');
+            for (index = 0; index < datetime.MONTH.length; index += 1) {
+              el = datetime.MONTH[index];
+              if (rawDate.indexOf(el) > -1) {
+                rawDate = rawDate.replace(el, index + 1);
+                break;
+              }
+            }
 
-            formatDate = formatDate.filter(function (item) {
+            dateSplit = rawDate.split(/\D/);
+
+            dateSplit = dateSplit.filter(function dateSplitFilter(item) {
+              if (item.length > 0) {
+                return item;
+              }
+            });
+
+            formatDate = formatDate.filter(function fromatDateFilter(item) {
               if (item.match(/^[a-zA-Z]+$/i) !== null) {
                 return item;
               }
             });
 
-            for (var index = 0; index < formatDate.length; index++) {
-              var element = formatDate[index];
+            for (index = 0; index < formatDate.length; index += 1) {
+              el = formatDate[index];
 
-              if (element.indexOf('d') > -1) {
+              if (el.indexOf('d') > -1) {
                 d = dateSplit[index];
               }
 
-              if (element.indexOf('M') > -1) {
+              if (el.indexOf('M') > -1) {
                 m = dateSplit[index];
               }
 
-              if (element.indexOf('y') > -1) {
+              if (el.indexOf('y') > -1) {
                 y = dateSplit[index];
               }
             }

--- a/src/js/angular-datepicker.js
+++ b/src/js/angular-datepicker.js
@@ -276,6 +276,41 @@
 
             $scope.year = Number($scope.year) + 1;
           }
+          , localDateTimestamp = function localDateTimestamp(rawDate, dateFormat) {
+            
+            var formattingTokens = /(\[[^\[]*\])|(\\)?([Hh]mm(ss)?|MM?M?M?|dd?d?|yy?yy?y?|gg(ggg?)?|GG(GGG?)?|e|E|a|A|hh?|HH?|kk?|mm?|ss?|S{1,9}|x|X|zz?|ZZ?|.)/g;
+            var formatDate = dateFormat.match(formattingTokens);
+            var dateSplit = rawDate.split(/\D/);
+            var m;
+            var d;
+            var y;
+
+            console.log('tutu');
+
+            formatDate = formatDate.filter(function (item) {
+              if (item.match(/^[a-zA-Z]+$/i) !== null) {
+                return item;
+              }
+            });
+
+            for (var index = 0; index < formatDate.length; index++) {
+              var element = formatDate[index];
+
+              if (element.indexOf('d') > -1) {
+                d = dateSplit[index];
+              }
+
+              if (element.indexOf('M') > -1) {
+                m = dateSplit[index];
+              }
+
+              if (element.indexOf('y') > -1) {
+                y = dateSplit[index];
+              }
+            }
+
+            return new Date(y + '/' + m + '/' + d);
+          }
           , setInputValue = function setInputValue() {
 
             if ($scope.isSelectableMinDate($scope.year + '/' + $scope.monthNumber + '/' + $scope.day) &&
@@ -618,9 +653,8 @@
                 thisInput[0].value.length > 0) {
 
                 try {
-
                   if (dateFormat) {
-                    date = new Date($filter('date')(thisInput[0].value.toString(), dateFormat));
+                    date = localDateTimestamp(thisInput[0].value.toString(), dateFormat);
                   } else {
                     date = new Date(thisInput[0].value.toString());
                   }


### PR DESCRIPTION
If language local date format has different order like standard
"English", then selection in popup calendar get invalid date. For
example, Czech or Slovak date format start with day number (dd.MM.yy).
If date format not start with month number, then new Date() parse
invalid date or if day number is not bigger then 12, switch day and
month