### PR TITLE
Show calendar with respect to date format

### DIFF
--- a/src/js/angular-datepicker.js
+++ b/src/js/angular-datepicker.js
@@ -158,7 +158,6 @@
           //, dateMaxLimit
           , dateDisabledDates = $scope.$eval($scope.dateDisabledDates)
           , date = new Date()
-          , dateString
           , isMouseOn = false
           , isMouseOnInput = false
           , preventMobile = typeof attr.datepickerMobile !== 'undefined' && attr.datepickerMobile !== 'false'
@@ -405,8 +404,11 @@
             if (theCalendar.classList) {
 
               theCalendar.classList.add('_720kb-datepicker-open');
-              dateString = angular.element(angular.element(theCalendar).parent()[0].querySelector('input')).val().replace(/\//g, '-');
-              date = new Date(dateString);
+              if (dateFormat) {
+                date = localDateTimestamp(thisInput[0].value.toString(), dateFormat);
+              } else {
+                date = new Date(thisInput[0].value.toString());
+              }
               $scope.selectedMonth = Number($filter('date')(date, 'MM'));
               $scope.selectedDay = Number($filter('date')(date, 'dd'));
               $scope.selectedYear = Number($filter('date')(date, 'yyyy'));


### PR DESCRIPTION
Current version may display calendar with incorrect month if you set date format to "dd/MM/yyyy" but your local date format has reverse day and month order like "MM/dd/yyyy"