### PR TITLE
Fixed: date parse error when opening calendar with "special" date format string

### DIFF
--- a/src/js/angular-datepicker.js
+++ b/src/js/angular-datepicker.js
@@ -313,15 +313,15 @@
 
               switch (true) {
                 case el.indexOf('d') !== -1: {
-                  d = dateSplit[index];
+                  d = dateSplit[index - (formatDate.length - dateSplit.length)];
                   break;
                 }
                 case el.indexOf('M') !== -1: {
-                  m = dateSplit[index];
+                  m = dateSplit[index - (formatDate.length - dateSplit.length)];
                   break;
                 }
                 case el.indexOf('y') !== -1: {
-                  y = dateSplit[index];
+                  y = dateSplit[index - (formatDate.length - dateSplit.length)];
                   break; 
                 }
                 default: {


### PR DESCRIPTION
In case the `date-format` string included other specifiers than day, month or year, the date wasn't parsed correctly in other languages when opening the calendar. For instance the format `EEE dd.MM.yyyy` wasn’t parsed correctly. This was due to the fact that the `localDateTimestamp` function only looked for specifiers for day, month and year and in case other specifiers existed it wouldn't ignore them, thereby messing up its lookup index in the date string. 

The fix basically ignores other specifiers and looks up the day, month and year in the input string correctly.