### PR TITLE
date-enabled-dates should work even if the list of dates is empty, disabling all the dates

### DIFF
--- a/src/js/angular-datepicker.js
+++ b/src/js/angular-datepicker.js
@@ -809,8 +809,7 @@
             }
           }
 
-          if (dateEnabledDates &&
-            dateEnabledDates.length > 0) {
+          if (dateEnabledDates) {
 
             for (i; i <= dateEnabledDates.length; i += 1) {
 


### PR DESCRIPTION
If the attribute 'date-enable-dates' is present and the list is empty, the component should work disabling all the dates.