### PR TITLE
Fix the forgotten comma

### DIFF
--- a/src/css/angular-datepicker.css
+++ b/src/css/angular-datepicker.css
@@ -180,7 +180,7 @@ datepicker, .datepicker, [datepicker],
   text-align: center;
   color:rgba(0,0,0,0.7);
 }
-._720kb-datepicker-calendar-days
+._720kb-datepicker-calendar-days,
 ._720kb-datepicker-default-button{
   font-size: 18.5px;
   position: relative;


### PR DESCRIPTION
A comma is missing at the end of the line, causing the -._720kb-datepicker-calendar-days to be ignored.